### PR TITLE
Fix Windows case-sensitive env values; remove unused code; fix shebangCommand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Run tests
         run: |
-          npx spago test
+          npx spago -x test.dhall test
 
       - name: Check Formatting
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
-# Run CI when a PR is opened against the branch `main`
-# and when one pushes a commit to `main`.
+# Run CI when a PR is opened against the branch `master`
+# and when one pushes a commit to `master`.
 on:
   push:
     branches: [master]
@@ -11,30 +11,42 @@ on:
 # Run CI on all 3 latest OSes
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: purescript-contrib/setup-purescript@main
+      - name: Set up Node toolchain
+        uses: actions/setup-node@v3
         with:
-          purescript: "0.15.7"
-          purs-tidy: "0.9.2"
-          psa: "0.8.2"
-          spago: "0.20.9"
+          node-version: "16"
+
+      - name: Cache NPM dependencies
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Setup PureScript tooling
+        run:
+          npm i -g purescript@latest purs-tidy@latest purescript-psa@latest spago@latest
 
       - name: Cache PureScript dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-spago-${{ hashFiles('**/*.dhall') }}
           path: |
             .spago
             output
-
-      - name: Set up Node toolchain
-        uses: actions/setup-node@v2
-        with:
-          node-version: "16"
 
       # Compile the library/project
       #   censor-lib: ignore warnings emitted by dependencies
@@ -42,12 +54,13 @@ jobs:
       # Note: `purs-args` actually forwards these args to `psa`
       - name: Build the project
         run: |
-          spago build --purs-args "--censor-lib --strict"
+          npx spago build --purs-args "--censor-lib --strict"
 
       - name: Run tests
         run: |
-          spago -x test.dhall test
+          npx spago test
 
       - name: Check Formatting
+        if: runner.os == 'Linux'
         run: |
-          purs-tidy check src test
+          npx purs-tidy check src test

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ PureScript port of the [`execa`](https://github.com/sindresorhus/execa) ([NPM li
 - [`signal-exit`](https://github.com/tapjs/signal-exit) - ISC
 - [`strip-final-newline`](https://github.com/sindresorhus/strip-final-newline) - MIT
 - [`which`](https://github.com/npm/node-which) - ISC
+- [`path-key`](https://github.com/sindresorhus/path-key) - MIT
+  - Note: personal experience indicates that Windows still uses case-sensitive keys for its environment. So ignore [path-key#8](https://github.com/sindresorhus/path-key/issues/8). This library's functionality was implemented via `envKey` so that other case-sensitivity issues do not arise on Windows. 
 
 The below dependencies of `execa` did not need to be ported since such functionality was implemented primarily via `Aff`.
 - `mimic-fn` - functionality unneeded as `Aff` `Fiber`s are a more flexible implementation than `Promise`s.
 - `onetime` - functionality provided via `Aff`'s `joinFiber`
 - `is-stream` - functionality provided via PureScript's types
-- `path-key` - functionality is no longer needed in current versions of Node

--- a/src/Node/Library/Execa.purs
+++ b/src/Node/Library/Execa.purs
@@ -446,7 +446,7 @@ execa file args buildOptions = do
           , stderr: result.stderr.text
           , command
           , escapedCommand
-          , parsed
+          , execaOptions: parsed.options
           , timedOut: is _TimedOut someError
           , isCanceled
           , killed: killed'
@@ -638,7 +638,7 @@ execaSync file args buildOptions = do
       , error: resultError
       , signal: resultSignal
       , exitCode: toMaybe result.status
-      , parsed
+      , execaOptions: parsed.options
       , timedOut: Just "ETIMEDOUT" == (map _.code resultError)
       , isCanceled: false
       , killed: isJust resultSignal
@@ -807,7 +807,7 @@ mkError
      , exitCode :: Maybe Int
      , command :: String
      , escapedCommand :: String
-     , parsed :: { file :: String, args :: Array String, options :: ExecaRunOptions, parsed :: CrossSpawnConfig }
+     , execaOptions :: ExecaRunOptions
      , timedOut :: Boolean
      , isCanceled :: Boolean
      , killed :: Boolean
@@ -835,7 +835,7 @@ mkError r =
   errorCode = map _.code r.error
   prefix
     | r.timedOut
-    , Just timeout <- r.parsed.options.timeout =
+    , Just timeout <- r.execaOptions.timeout =
         "timed out after " <> show timeout <> "milliseconds"
     | r.isCanceled =
         "was canceled"

--- a/src/Node/Library/Execa/CrossSpawn.purs
+++ b/src/Node/Library/Execa/CrossSpawn.purs
@@ -104,7 +104,7 @@ parse command args options = do
         -- Because the escape of metachars with ^ gets interpreted when the cmd.exe is first called,
         -- we need to double escape them
         let needsDoubleEscapeChars = test isCommandShimRegex commandFile
-        comSpec <- fromMaybe "cmd.exe" <$> lookupEnv "comspec"
+        comSpec <- fromMaybe "cmd.exe" <$> lookupEnv "ComSpec"
         pure $ rec1
           { args =
               -- PureScript note: This fix is done in `execa` since
@@ -156,7 +156,7 @@ parse command args options = do
       Nothing -> Process.getEnv
       Just a -> pure a
     resolved <- withOptionsCwdIfNeeded parseRec.options.cwd \_ -> do
-      map join $ for (Object.lookup "PATH" env) \envPath -> do
+      map join $ for (Object.lookup "Path" env) \envPath -> do
         let getFirst = either (const Nothing) (Just <<< NEA.head)
         attempt1 <- map getFirst $ Which.whichSync command $ defaultWhichOptions { path = Just envPath, pathExt = Just Path.delimiter }
         if isJust attempt1 then do

--- a/src/Node/Library/Execa/CrossSpawn.purs
+++ b/src/Node/Library/Execa/CrossSpawn.purs
@@ -33,13 +33,13 @@ import Node.Encoding (Encoding(..))
 import Node.FS (FileFlags(..))
 import Node.FS.Sync as FS
 import Node.Library.Execa.ShebangCommand (shebangCommand)
-import Node.Library.Execa.Utils (bracketEffect)
+import Node.Library.Execa.Utils (bracketEffect, envKey)
 import Node.Library.Execa.Which (defaultWhichOptions)
 import Node.Library.Execa.Which as Which
 import Node.Path (normalize)
 import Node.Path as Path
 import Node.Platform (Platform(..))
-import Node.Process (lookupEnv, platform)
+import Node.Process (platform)
 import Node.Process as Process
 
 isWindows :: Boolean
@@ -97,7 +97,7 @@ parse command args options = do
         -- Because the escape of metachars with ^ gets interpreted when the cmd.exe is first called,
         -- we need to double escape them
         let needsDoubleEscapeChars = test isCommandShimRegex commandFile
-        comSpec <- fromMaybe "cmd.exe" <$> lookupEnv "ComSpec"
+        comSpec <- fromMaybe "cmd.exe" <$> envKey "COMSPEC"
         pure $ rec1
           { args =
               -- PureScript note: This fix is done in `execa` since

--- a/src/Node/Library/Execa/IsExe.purs
+++ b/src/Node/Library/Execa/IsExe.purs
@@ -28,8 +28,9 @@ import Effect.Uncurried (EffectFn2, runEffectFn2)
 import Node.FS.Async as FsAsync
 import Node.FS.Stats (Stats(..), isFile, isSymbolicLink)
 import Node.FS.Sync as FsSync
+import Node.Library.Execa.Utils (envKey)
 import Node.Platform (Platform(..))
-import Node.Process (lookupEnv, platform)
+import Node.Process (platform)
 import Unsafe.Coerce (unsafeCoerce)
 
 type IsExeOptions =
@@ -98,7 +99,7 @@ coreWindows =
 
   checkPathExt :: String -> IsExeOptions -> Effect Boolean
   checkPathExt path options = do
-    mbPathExt <- lookupEnv "PATHEXT"
+    mbPathExt <- envKey "PATHEXT"
     case options.pathExt <|> mbPathExt of
       Nothing -> pure true
       Just p -> do

--- a/src/Node/Library/Execa/NpmRunPath.purs
+++ b/src/Node/Library/Execa/NpmRunPath.purs
@@ -13,6 +13,7 @@ import Data.Maybe (Maybe(..), fromMaybe)
 import Effect (Effect)
 import Foreign.Object (Object)
 import Foreign.Object as Object
+import Node.Library.Execa.Utils (envKey)
 import Node.Path as Path
 import Node.Process as Process
 
@@ -33,7 +34,7 @@ defaultNpmRunPathOptions = mempty
 npmRunPath :: NpmRunPathOptions -> Effect String
 npmRunPath initialOptions = do
   processCwd <- Process.cwd
-  processPath <- Process.lookupEnv "PATH"
+  processPath <- envKey "PATH"
   processExecPath <- Process.execPath
   let
     options =

--- a/src/Node/Library/Execa/Which.purs
+++ b/src/Node/Library/Execa/Which.purs
@@ -23,20 +23,18 @@ import Data.Tuple (Tuple(..))
 import Effect (Effect)
 import Effect.Aff (Aff)
 import Effect.Class (liftEffect)
-import Foreign.Object as Object
 import Node.Library.Execa.IsExe (defaultIsExeOptions, isExe, isExeSync)
+import Node.Library.Execa.Utils (CustomError, buildCustomError, envKey)
 import Node.Path as Path
 import Node.Platform (Platform(..))
 import Node.Process (platform)
 import Node.Process as Process
-import Node.Library.Execa.Utils (CustomError, buildCustomError)
 import Partial.Unsafe (unsafePartial)
 
 isWindows :: Effect Boolean
 isWindows = do
-  env <- Process.getEnv
-  let osTypeIs x = Just x == Object.lookup "OSTYPE" env
-  pure $ platform == Just Win32 || osTypeIs "cygwin" || osTypeIs "msys"
+  ty <- envKey "OSTYPE"
+  pure $ platform == Just Win32 || ty == Just "cygwin" || ty == Just "msys"
 
 jsColon :: Effect String
 jsColon = do
@@ -72,8 +70,8 @@ getPathInfo cmd options = do
   -- PureScript implementation note: get all the effectful stuff first
   -- before we use it in the rest of this function for readability.
   cwd <- Process.cwd
-  mbPath <- Process.lookupEnv "PATH"
-  mbPathExt <- Process.lookupEnv "PATHEXT"
+  mbPath <- envKey "PATH"
+  mbPathExt <- envKey "PATHEXT"
   isWin <- isWindows
 
   colon <- case options.colon of

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -5,9 +5,12 @@ import Prelude
 import Effect (Effect)
 import Effect.Aff (launchAff_)
 import Test.Node.Library.Execa as Execa
+import Test.Node.Library.ParseCommand as ParseCommand
 import Test.Spec.Reporter (consoleReporter)
-import Test.Spec.Runner (defaultConfig, runSpecT)
+import Test.Spec.Runner (runSpec)
 
 main :: Effect Unit
-main = launchAff_ $ void $ join $ runSpecT defaultConfig [ consoleReporter ] do
-  Execa.spec
+main = launchAff_ $ do
+  runSpec [ consoleReporter ] do
+    Execa.spec
+    ParseCommand.spec

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -6,6 +6,7 @@ import Effect (Effect)
 import Effect.Aff (launchAff_)
 import Test.Node.Library.Execa as Execa
 import Test.Node.Library.ParseCommand as ParseCommand
+import Test.Node.Library.ShebangCommand as ShebangCommand
 import Test.Spec.Reporter (consoleReporter)
 import Test.Spec.Runner (runSpec)
 
@@ -14,3 +15,4 @@ main = launchAff_ $ do
   runSpec [ consoleReporter ] do
     Execa.spec
     ParseCommand.spec
+    ShebangCommand.spec

--- a/test/Test/Node/Library/Execa.purs
+++ b/test/Test/Node/Library/Execa.purs
@@ -12,6 +12,8 @@ import Node.Library.Execa (execa, execaCommand, execaCommandSync, execaSync)
 import Node.Library.Execa.ParseCommand (parseCommand')
 import Node.Library.Execa.Utils (utf8)
 import Node.Library.HumanSignals (signals)
+import Node.Platform (Platform(..))
+import Node.Process as Process
 import Test.Spec (Spec, describe, it)
 import Test.Spec.Assertions (fail, shouldEqual)
 import Test.Spec.Assertions.String (shouldContain)
@@ -19,6 +21,14 @@ import Test.Spec.Assertions.String (shouldContain)
 spec :: Spec Unit
 spec = do
   describe "execa" do
+    if (Process.platform /= Just Win32) then do
+      nixTests
+    else
+      windowsTests
+
+nixTests :: Spec Unit
+nixTests = do
+  describe "*nix" do
     it "`echo test` should fail due to a Node.js bug" do
       spawned <- execa "echo" [] identity
       spawned.stdin.writeUtf8End "test"
@@ -167,3 +177,7 @@ spec = do
         , (squote <> "a" <> escDQuote <> "b" <> squote) /\ ("a" <> escDQuote <> "b")
         ]
 
+windowsTests :: Spec Unit
+windowsTests = do
+  describe "windows" do
+    pure unit

--- a/test/Test/Node/Library/Execa.purs
+++ b/test/Test/Node/Library/Execa.purs
@@ -2,89 +2,96 @@ module Test.Node.Library.Execa where
 
 import Prelude
 
-import Data.Array as Array
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
-import Data.Tuple (fst, snd)
-import Data.Tuple.Nested ((/\))
 import Effect.Class (liftEffect)
 import Node.Library.Execa (execa, execaCommand, execaCommandSync, execaSync)
-import Node.Library.Execa.ParseCommand (parseCommand')
 import Node.Library.Execa.Utils (utf8)
 import Node.Library.HumanSignals (signals)
 import Node.Platform (Platform(..))
 import Node.Process as Process
-import Test.Spec (Spec, describe, it)
+import Test.Spec (class Example, Spec, SpecT, describe, it)
 import Test.Spec.Assertions (fail, shouldEqual)
 import Test.Spec.Assertions.String (shouldContain)
 
-spec :: Spec Unit
-spec = do
-  describe "execa" do
-    if (Process.platform /= Just Win32) then do
-      nixTests
-    else
-      windowsTests
+isWindows :: Boolean
+isWindows = Process.platform == Just Win32
 
-nixTests :: Spec Unit
-nixTests = do
-  describe "*nix" do
-    it "`echo test` should fail due to a Node.js bug" do
-      spawned <- execa "echo" [] identity
+itWindows :: forall m t arg g. Monad m => Example t arg g => String -> t -> SpecT g arg m Unit
+itWindows msg test = do
+  when isWindows do
+    it (msg <> " (windows only)") test
+
+itNix :: forall m t arg g. Monad m => Example t arg g => String -> t -> SpecT g arg m Unit
+itNix msg test = do
+  unless isWindows do
+    it (msg <> " (*nix only)") test
+
+spec :: Spec Unit
+spec = describe "execa" do
+  itNix "`echo test` should fail due to a Node.js bug" do
+    spawned <- execa "echo" [] identity
+    spawned.stdin.writeUtf8End "test"
+    result <- spawned.result
+    case result of
+      Right _ -> fail "Expected EPIPE error"
+      Left e -> e.message `shouldContain` "EPIPE"
+  describe "`cat` tests" do
+    it "input is file" do
+      spawned <- execa "cat" [ "test.dhall" ] identity
+      result <- spawned.result
+      case result of
+        Right r -> r.stdout `shouldContain` "let config ="
+        Left e -> fail e.message
+    itNix "input is buffer" do
+      spawned <- execa "cat" [ "-" ] identity
       spawned.stdin.writeUtf8End "test"
       result <- spawned.result
       case result of
-        Right _ -> fail "Expected EPIPE error"
-        Left e -> e.message `shouldContain` "EPIPE"
-    describe "`cat` tests" do
-      it "input is file" do
-        spawned <- execa "cat" [ "test.dhall" ] identity
-        result <- spawned.result
-        case result of
-          Right r -> r.stdout `shouldContain` "let config ="
-          Left e -> fail e.message
-      it "input is buffer" do
-        spawned <- execa "cat" [ "-" ] identity
-        spawned.stdin.writeUtf8End "test"
-        result <- spawned.result
-        case result of
-          Right r -> r.stdout `shouldEqual` "test"
-          Left e -> fail e.message
-    describe "kill works" do
-      it "basic cancel produces error" do
-        spawned <- execa "bash" [ "test/fixtures/sleep.sh", "1" ] identity
-        spawned.cancel
-        result <- spawned.result
-        case result of
-          Right _ -> fail "Cancelling should work"
-          Left e -> e.isCanceled `shouldEqual` true
-      it "basic kill (string) produces error" do
-        spawned <- execa "bash" [ "test/fixtures/sleep.sh", "1" ] identity
-        _ <- spawned.killWithSignal (Right "SIGTERM")
-        result <- spawned.result
-        case result of
-          Right _ -> fail "Cancelling should work"
-          Left e -> e.signal `shouldEqual` (Just $ Right "SIGTERM")
-      it "basic kill (int) produces error" do
-        spawned <- execa "bash" [ "test/fixtures/sleep.sh", "1" ] identity
-        _ <- spawned.killWithSignal (Left signals.byName."SIGTERM".number)
-        result <- spawned.result
-        case result of
-          Right _ -> fail "Cancelling should work"
-          Left e -> case e.signal of
-            Just (Left i) -> i `shouldEqual` signals.byName."SIGTERM".number
-            Just (Right s) -> s `shouldEqual` signals.byName."SIGTERM".name
-            _ -> fail "Did not get a kill signal"
-    describe "timeout produces error" do
-      it "basic timeout produces error" do
-        spawned <- execa "bash" [ "test/fixtures/sleep.sh", "10" ]
-          (_ { timeout = Just { milliseconds: 400.0, killSignal: Right "SIGTERM" } })
-        result <- spawned.result
-        case result of
-          Right _ -> fail "Timeout should work"
-          Left e -> do
-            e.signal `shouldEqual` (Just $ Right "SIGTERM")
-            e.timedOut `shouldEqual` true
+        Right r -> r.stdout `shouldEqual` "test"
+        Left e -> fail e.message
+  describe "kill works" do
+    itNix "basic cancel produces error" do
+      spawned <- execa "bash" [ "test/fixtures/sleep.sh", "1" ] identity
+      spawned.cancel
+      result <- spawned.result
+      case result of
+        Right _ -> fail "Cancelling should work"
+        Left e -> e.isCanceled `shouldEqual` true
+    itWindows "basic cancel produces error" do
+      spawned <- execa "test/fixtures/sleep.cmd" [ "1" ] identity
+      spawned.cancel
+      result <- spawned.result
+      case result of
+        Right _ -> fail "Cancelling should work"
+        Left e -> e.isCanceled `shouldEqual` true
+    itNix "basic kill (string) produces error" do
+      spawned <- execa "test/fixtures/sleep.cmd" [ "1" ] identity
+      _ <- spawned.killWithSignal (Right "SIGTERM")
+      result <- spawned.result
+      case result of
+        Right _ -> fail "Cancelling should work"
+        Left e -> e.signal `shouldEqual` (Just $ Right "SIGTERM")
+    itNix "basic kill (int) produces error" do
+      spawned <- execa "test/fixtures/sleep.cmd" [ "1" ] identity
+      _ <- spawned.killWithSignal (Left signals.byName."SIGTERM".number)
+      result <- spawned.result
+      case result of
+        Right _ -> fail "Cancelling should work"
+        Left e -> case e.signal of
+          Just (Left i) -> i `shouldEqual` signals.byName."SIGTERM".number
+          Just (Right s) -> s `shouldEqual` signals.byName."SIGTERM".name
+          _ -> fail "Did not get a kill signal"
+  describe "timeout produces error" do
+    itNix "basic timeout produces error" do
+      spawned <- execa "test/fixtures/sleep.cmd" [ "10" ]
+        (_ { timeout = Just { milliseconds: 400.0, killSignal: Right "SIGTERM" } })
+      result <- spawned.result
+      case result of
+        Right _ -> fail "Timeout should work"
+        Left e -> do
+          e.signal `shouldEqual` (Just $ Right "SIGTERM")
+          e.timedOut `shouldEqual` true
   describe "execaSync" do
     describe "`cat` tests" do
       it "input is file" do
@@ -92,7 +99,7 @@ nixTests = do
         case result of
           Right r -> r.stdout `shouldContain` "let config ="
           Left e -> fail e.message
-      it "input is buffer" do
+      itNix "input is buffer" do
         result <- liftEffect $ execaSync "cat" [ "-" ] (_ { input = Just $ utf8.toBuffer "test" })
         case result of
           Right r -> r.stdout `shouldEqual` "test"
@@ -105,7 +112,7 @@ nixTests = do
         case result of
           Right r -> r.stdout `shouldContain` "let config ="
           Left e -> fail e.message
-      it "input is buffer" do
+      itNix "input is buffer" do
         spawned <- execaCommand "cat -" identity
         spawned.stdin.writeUtf8End "test"
         result <- spawned.result
@@ -119,65 +126,8 @@ nixTests = do
         case result of
           Right r -> r.stdout `shouldContain` "let config ="
           Left e -> fail e.message
-      it "input is buffer" do
+      itNix "input is buffer" do
         result <- liftEffect $ execaCommandSync "cat" (_ { input = Just $ utf8.toBuffer "test" })
         case result of
           Right r -> r.stdout `shouldEqual` "test"
           Left e -> fail e.message
-  describe "parseCommand" do
-    let
-      shouldBeFileArgs file args = do
-        let result = parseCommand' $ (fst file) <> " " <> (Array.intercalate " " $ map fst args)
-        Right (snd file) `shouldEqual` (map _.file) result
-        Right (map snd args) `shouldEqual` (map _.args) result
-
-      escapeSlash = """\"""
-      backslash = escapeSlash
-      space = " "
-      escapedSpace = escapeSlash <> " "
-      dquote = "\""
-      squote = "'"
-      escSQuote = escapeSlash <> squote
-      escDQuote = escapeSlash <> dquote
-      escBackslash = escapeSlash <> backslash
-
-    it "should work despite extra spaces" do
-      shouldBeFileArgs
-        (" file  " /\ "file")
-        [ "    arg1" /\ "arg1"
-        , "arg2   " /\ "arg2"
-        , "   arg3   " /\ "arg3"
-        ]
-
-    it "should account for escaped spaces, double-quotes, single-quotes, and back slashes" do
-      shouldBeFileArgs
-        ("file" /\ "file")
-        [ ("a" <> escapedSpace <> "b") /\ ("a" <> space <> "b")
-        , ("a" <> escDQuote <> "b") /\ ("a" <> dquote <> "b")
-        , ("a" <> escSQuote <> "b") /\ ("a" <> squote <> "b")
-        , ("a" <> escBackslash <> "b") /\ ("a" <> backslash <> "b")
-        ]
-
-    it "should account for escaped double-quotes within double-quote context" do
-      shouldBeFileArgs
-        ("file" /\ "file")
-        [ (dquote <> "a" <> escDQuote <> "b" <> dquote) /\ ("a" <> dquote <> "b")
-        ]
-
-    it "should account for escaped single-quotes within single-quote context" do
-      shouldBeFileArgs
-        ("file" /\ "file")
-        [ (squote <> "a" <> escSQuote <> "b" <> squote) /\ ("a" <> squote <> "b")
-        ]
-
-    it "should account for ignore all other escaped chars in a double- or single-quote context" do
-      shouldBeFileArgs
-        ("file" /\ "file")
-        [ (dquote <> "a" <> escSQuote <> "b" <> dquote) /\ ("a" <> escSQuote <> "b")
-        , (squote <> "a" <> escDQuote <> "b" <> squote) /\ ("a" <> escDQuote <> "b")
-        ]
-
-windowsTests :: Spec Unit
-windowsTests = do
-  describe "windows" do
-    pure unit

--- a/test/Test/Node/Library/Execa.purs
+++ b/test/Test/Node/Library/Execa.purs
@@ -7,17 +7,16 @@ import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Data.Tuple (fst, snd)
 import Data.Tuple.Nested ((/\))
-import Effect.Aff (Aff)
 import Effect.Class (liftEffect)
 import Node.Library.Execa (execa, execaCommand, execaCommandSync, execaSync)
 import Node.Library.Execa.ParseCommand (parseCommand')
 import Node.Library.Execa.Utils (utf8)
 import Node.Library.HumanSignals (signals)
-import Test.Spec (SpecT, describe, it)
+import Test.Spec (Spec, describe, it)
 import Test.Spec.Assertions (fail, shouldEqual)
 import Test.Spec.Assertions.String (shouldContain)
 
-spec :: SpecT Aff Unit Aff Unit
+spec :: Spec Unit
 spec = do
   describe "execa" do
     it "`echo test` should fail due to a Node.js bug" do

--- a/test/Test/Node/Library/ParseCommand.purs
+++ b/test/Test/Node/Library/ParseCommand.purs
@@ -1,0 +1,67 @@
+module Test.Node.Library.ParseCommand where
+
+import Prelude
+
+import Data.Array as Array
+import Data.Either (Either(..))
+import Data.Tuple (fst, snd)
+import Data.Tuple.Nested ((/\))
+import Node.Library.Execa.ParseCommand (parseCommand')
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual)
+
+spec :: Spec Unit
+spec = do
+  describe "parseCommand" do
+    let
+      shouldBeFileArgs file args = do
+        let result = parseCommand' $ (fst file) <> " " <> (Array.intercalate " " $ map fst args)
+        Right (snd file) `shouldEqual` (map _.file) result
+        Right (map snd args) `shouldEqual` (map _.args) result
+
+      escapeSlash = """\"""
+      backslash = escapeSlash
+      space = " "
+      escapedSpace = escapeSlash <> " "
+      dquote = "\""
+      squote = "'"
+      escSQuote = escapeSlash <> squote
+      escDQuote = escapeSlash <> dquote
+      escBackslash = escapeSlash <> backslash
+
+    it "should work despite extra spaces" do
+      shouldBeFileArgs
+        (" file  " /\ "file")
+        [ "    arg1" /\ "arg1"
+        , "arg2   " /\ "arg2"
+        , "   arg3   " /\ "arg3"
+        ]
+
+    it "should account for escaped spaces, double-quotes, single-quotes, and back slashes" do
+      shouldBeFileArgs
+        ("file" /\ "file")
+        [ ("a" <> escapedSpace <> "b") /\ ("a" <> space <> "b")
+        , ("a" <> escDQuote <> "b") /\ ("a" <> dquote <> "b")
+        , ("a" <> escSQuote <> "b") /\ ("a" <> squote <> "b")
+        , ("a" <> escBackslash <> "b") /\ ("a" <> backslash <> "b")
+        ]
+
+    it "should account for escaped double-quotes within double-quote context" do
+      shouldBeFileArgs
+        ("file" /\ "file")
+        [ (dquote <> "a" <> escDQuote <> "b" <> dquote) /\ ("a" <> dquote <> "b")
+        ]
+
+    it "should account for escaped single-quotes within single-quote context" do
+      shouldBeFileArgs
+        ("file" /\ "file")
+        [ (squote <> "a" <> escSQuote <> "b" <> squote) /\ ("a" <> squote <> "b")
+        ]
+
+    it "should account for ignore all other escaped chars in a double- or single-quote context" do
+      shouldBeFileArgs
+        ("file" /\ "file")
+        [ (dquote <> "a" <> escSQuote <> "b" <> dquote) /\ ("a" <> escSQuote <> "b")
+        , (squote <> "a" <> escDQuote <> "b" <> squote) /\ ("a" <> escDQuote <> "b")
+        ]
+

--- a/test/Test/Node/Library/ShebangCommand.purs
+++ b/test/Test/Node/Library/ShebangCommand.purs
@@ -1,0 +1,36 @@
+module Test.Node.Library.ShebangCommand where
+
+import Prelude
+
+import Data.Array as Array
+import Data.Foldable (for_)
+import Data.Maybe (Maybe(..))
+import Data.Monoid (guard)
+import Node.Library.Execa.ShebangCommand (shebangCommand)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual)
+
+spec :: Spec Unit
+spec = do
+  describe "shebangCommand" do
+    let
+      tests = do
+        space <- [ true, false ]
+        wrapEnv <- [ true, false ]
+        argCount <- [ 0, 1, 2 ]
+        pure { space, wrapEnv, argCount }
+
+    for_ tests \r -> do
+      let
+        expected =
+          Array.intercalate " "
+            $ Array.cons "foo"
+            $ Array.replicate r.argCount "a"
+        cmd =
+          append "#!"
+            $ append (guard r.space " ")
+            $ append (if r.wrapEnv then "/usr/bin/env " else "/")
+            $ expected
+      it ("should parse `" <> cmd <> "` as `" <> expected <> "`") do
+        shebangCommand cmd `shouldEqual` (Just expected)
+

--- a/test/Test/Node/Library/Utils.purs
+++ b/test/Test/Node/Library/Utils.purs
@@ -1,0 +1,31 @@
+module Test.Node.Library.Utils where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Node.Platform (Platform(..))
+import Node.Process as Process
+import Test.Spec (class Example, SpecT, describe, it)
+
+isWindows :: Boolean
+isWindows = Process.platform == Just Win32
+
+itWindows :: forall m t arg g. Monad m => Example t arg g => String -> t -> SpecT g arg m Unit
+itWindows msg test = do
+  when isWindows do
+    it (msg <> " (windows only)") test
+
+itNix :: forall m t arg g. Monad m => Example t arg g => String -> t -> SpecT g arg m Unit
+itNix msg test = do
+  unless isWindows do
+    it (msg <> " (*nix only)") test
+
+describeWindows :: forall g i m. Monad m => String → SpecT g i m Unit → SpecT g i m Unit
+describeWindows msg test = do
+  when isWindows do
+    describe (msg <> " (windows only)") test
+
+describeNix :: forall g i m. Monad m => String → SpecT g i m Unit → SpecT g i m Unit
+describeNix msg test = do
+  unless isWindows do
+    describe (msg <> " (*nix only)") test

--- a/test/fixtures/outErr.cmd
+++ b/test/fixtures/outErr.cmd
@@ -1,0 +1,2 @@
+echo "stdout"
+echo "stderr" 1>&2

--- a/test/fixtures/sleep.cmd
+++ b/test/fixtures/sleep.cmd
@@ -1,0 +1,3 @@
+set seconds=%1
+ping 127.0.0.1 -n %seconds% > nul
+echo "Finish"

--- a/test/fixtures/sleep.sh
+++ b/test/fixtures/sleep.sh
@@ -2,6 +2,6 @@
 
 TIMEOUT_SECONDS=$1
 
-sleep "${TIMEOUT_SECONDS}s"
+sleep "${TIMEOUT_SECONDS}"
 
 echo "Finish"


### PR DESCRIPTION
- Windows env is case-sensitive
- Drop unused args from CrossSpawn
- Fix windows case-sensitivity in env lookup
