### PR TITLE
Fix ENOENT 127 code; stop forever block on ENOENT; cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Node toolchain
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "lts/*"
 
       - name: Cache NPM dependencies
         uses: actions/cache@v3

--- a/src/Node/Library/Execa.purs
+++ b/src/Node/Library/Execa.purs
@@ -353,7 +353,7 @@ execa file args buildOptions = do
   let
     mainFiber
       :: Maybe (Pid -> Aff Unit)
-      -> Aff _
+      -> Aff ExecaResult
     mainFiber postSpawn = do
       res <- joinFiber processSpawnedFiber
       case res of

--- a/src/Node/Library/Execa.purs
+++ b/src/Node/Library/Execa.purs
@@ -42,7 +42,7 @@ import Foreign.Object (Object)
 import Foreign.Object as Object
 import Node.Buffer (Buffer)
 import Node.Buffer as Buffer
-import Node.ChildProcess (ChildProcess, kill', pid)
+import Node.ChildProcess (ChildProcess)
 import Node.ChildProcess as CP
 import Node.ChildProcess.Aff (waitSpawned)
 import Node.ChildProcess.Types (Exit(..), KillSignal, StdIO, customShell, fromKillSignal, fromKillSignal', stringSignal)
@@ -529,7 +529,7 @@ execa file args buildOptions = do
             void $ Stream.pipe (CP.stderr spawned) Process.stderr
         }
     , waitSpawned: do
-        mbPid <- liftEffect $ pid spawned
+        mbPid <- liftEffect $ CP.pid spawned
         case mbPid of
           Just p -> pure $ Right p
           Nothing -> waitSpawned spawned
@@ -714,7 +714,7 @@ execaKill
 execaKill mbKillSignal forceKillAfterTimeout cp = do
   let
     killSignal = fromMaybe (stringSignal "SIGTERM") mbKillSignal
-  killSignalSucceeded <- kill' killSignal cp
+  killSignalSucceeded <- CP.kill' killSignal cp
   let
     mbTimeout = do
       guard $ isSigTerm killSignal
@@ -722,7 +722,7 @@ execaKill mbKillSignal forceKillAfterTimeout cp = do
       forceKillAfterTimeout
   for_ mbTimeout \(Milliseconds timeout) -> do
     t <- runEffectFn2 setTimeoutImpl (floor timeout) do
-      void $ kill' (stringSignal "SIGKILL") cp
+      void $ CP.kill' (stringSignal "SIGKILL") cp
     t.unref
   pure killSignalSucceeded
   where

--- a/src/Node/Library/Execa.purs
+++ b/src/Node/Library/Execa.purs
@@ -334,7 +334,7 @@ execa file args buildOptions = do
         ( do
             liftEffect do
               removal <- SignalExit.onExit \_ _ -> do
-                void $ execaKill (Just $ stringSignal "SIGTERM") Nothing spawned
+                void $ CP.kill' (stringSignal "SIGTERM") spawned
               Ref.write (Just removal) removeHandlerRef
             joinFiber spawnedFiber
         )
@@ -346,7 +346,7 @@ execa file args buildOptions = do
   let
     cancel :: Aff Unit
     cancel = liftEffect do
-      killSucceeded <- execaKill (Just $ stringSignal "SIGTERM") Nothing spawned
+      killSucceeded <- CP.kill' (stringSignal "SIGTERM") spawned
       when killSucceeded do
         Ref.write true canceledRef
 
@@ -424,7 +424,7 @@ execa file args buildOptions = do
                   tid <- setTimeout ((unsafeCoerce :: Milliseconds -> Int) milliseconds) do
                     killed' <- CP.killed spawned
                     unless killed' do
-                      void $ execaKill (Just signal) Nothing spawned
+                      void $ CP.kill' signal spawned
                       mbPid <- CP.pid spawned
                       for_ mbPid \_ -> do
                         -- stdin/out/err only exist if child process has spawned

--- a/test/Test/Node/Library/Execa.purs
+++ b/test/Test/Node/Library/Execa.purs
@@ -41,6 +41,11 @@ spec = describe "execa" do
       case result.exit of
         Normally 0 -> result.stdout `shouldEqual` "test"
         _ -> fail result.message
+  it "ENOENT should produce exit code 127" do
+    result <- _.getResult =<< execa "this-does-not-exist" [] identity
+    case result.exit of
+      Normally 127 -> mempty
+      _ -> fail $ "Should have gotten exit 127. " <> show result
   describe "using sleep files" do
     let
       shellCmd = if isWindows then "pwsh" else "sh"


### PR DESCRIPTION
Fixes #2 

While fixing this bug, I discovered that the refactoring done in #13 introduced a bug. Whenever one spawned a process that does not exist, the child process will never emit an `exit` event. Thus, the `processFinishedFiber` I was using to get back an `Exit` value would never return.

Part of the reason why I was doing that was to workaround another issue with `node-child-process`. `signalCode` per Node docs will return a `String`, but it should really be a kill signal as I'm not sure whether those docs may be wrong since one can kill a process with an int as well. :man_shrugging: 

Regardless, the current change to reading `exitCode` and `signalCode` and combining them into an `Exit` value works. If `signalCode` is actually an `Int` underneath, using `stringSignal` doesn't matter as its the same value as `intSignal`: `unsafeCoerce`.

Everything else in this PR cleans up a few things and defines more things within the 'Right' case (process spawned successfully) so as to be more local to where it is used. 