### PR TITLE
Fix environment handling in async version

### DIFF
--- a/src/Node/Library/Execa.purs
+++ b/src/Node/Library/Execa.purs
@@ -309,7 +309,7 @@ execa file args buildOptions = do
   spawned <- liftEffect $ CP.spawn' parsed.file parsed.args
     ( _
         { cwd = options.cwd
-        , env = options.env
+        , env = Just parsed.options.env
         , argv0 = options.argv0
         , appendStdio = options.stdioExtra
         , detached = options.detached


### PR DESCRIPTION
The sync version was using the parsed `env` correctly, but it didn't make it into the async version which meant that `extendEnv` did not work when `env` was set.

To reproduce:
```purescript
execa "env" [] _ { env = Just mempty, extendEnv = Just true }
```

would return only
```env
NODE_CHANNEL_FD=3
NODE_CHANNEL_SERIALIZATION_MODE=json
```